### PR TITLE
fix neon theme color

### DIFF
--- a/neoTUI.py
+++ b/neoTUI.py
@@ -81,7 +81,8 @@ class ThemeManager:
                 "success": "bright_green",
                 "warning": "bright_yellow",
                 "error": "bright_red",
-                "info": "electric_blue",
+                # rich doesn't support 'electric_blue'; use hex value instead
+                "info": "#7df9ff",
                 "dim": "dim bright_white",
                 "border": "bright_cyan"
             }


### PR DESCRIPTION
## Summary
- replace unsupported `electric_blue` with hex color in neon theme to avoid runtime errors

## Testing
- `python3 neoTUI.py theme neon`
- `python3 neoTUI.py ping 127.0.0.1`


------
https://chatgpt.com/codex/tasks/task_e_68aba0a1288c8324ae6d3b49414c01f2